### PR TITLE
Fix: fix random breaks of the websocket under high load

### DIFF
--- a/src/core/http_websocket_thread.h
+++ b/src/core/http_websocket_thread.h
@@ -84,6 +84,8 @@ private:
     websocket::stream<beast::ssl_stream<tcp::socket&>>* m_webSocket = nullptr;
     std::string m_uuid = "";
     std::string m_target = "";
+    bool m_waitForInput = true;
+    bool m_websocketClosed = true;
     Kitsunemimi::Hanami::HanamiMessagingClient* m_client = nullptr;
 };
 


### PR DESCRIPTION
## Description

Fix: fix random breaks of the websocket under high load

Added toggle-flag with small wait-loop to ensure, that the websocket can never listen and send at the same time to solve a race-condition, which appeard sometimes.

## Related Issues

- #14 

## How it was tested?

- tested in a another use-case with external code, which pushed a huge amound of data over the webseocket.
