### PR TITLE
Fix: fixed missing user-id in audit-log

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -26,8 +26,3 @@ jobs:
           cp -r ../result/* /build_result/
       - name: "Check target-directory"
         run: ls -l /build_result
-      - name: Create artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: result
-          path: /build_result

--- a/src/core/http_processing/http_processing.cpp
+++ b/src/core/http_processing/http_processing.cpp
@@ -281,7 +281,7 @@ processControlRequest(http::response<http::dynamic_body> &httpResponse,
     // send audit-message to shiori
     if(Shiori::sendAuditMessage(target,
                                 hanamiRequest.id,
-                                userData.get("uuid").getString(),
+                                userData.get("id").getString(),
                                 hanamiRequest.httpType,
                                 error) == false)
     {


### PR DESCRIPTION
## Description

Fix: fixed missing user-id in audit-log
The code was not up-to-data and still tried to use the uuid instead of the id of the user for the audit-log.

## Related Issues

- #18 

## How it was tested?

- Tsugumi
